### PR TITLE
Use Git Tags as additional Docker Image Tags

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.10.3
+
+ENTRYPOINT ["echo", "'hello world'"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           IMAGE_TAG: 'v0.0'
           DOCKERFILE_PATH: '.github/docker/Dockerfile'
           BUILD_CONTEXT: './'
-      - name: Build and Publish Docker image in GPR
+      - name: Build and Publish Docker image to Dockerhub instead of GPR
         uses: saubermacherag/gpr-docker-publish@master
         with:
           USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -28,4 +28,4 @@ jobs:
           IMAGE_TAG: 'v0.0'
           DOCKERFILE_PATH: '.github/docker/Dockerfile'
           BUILD_CONTEXT: './'
-          DOCKERHUB_REPOSITORY: 'pinkrobin/docker-ansible-alpine'
+          DOCKERHUB_REPOSITORY: 'pinkrobin/gpr-docker-publish-example'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: Test Docker Image Creation
+
+on: [push]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Build and Publish Docker image
+        uses: saubermacherag/gpr-docker-publish@master
+        with:
+          USERNAME: x-access-token
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_NAME: 'gpr-docker-publish-test'
+          IMAGE_TAG: 'v0.0'
+          DOCKERFILE_PATH: '.github/docker/Dockerfile'
+          BUILD_CONTEXT: './'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
-      - name: Build and Publish Docker image
+      - name: Build and Publish Docker image in GPR
         uses: saubermacherag/gpr-docker-publish@master
         with:
           USERNAME: x-access-token
@@ -20,3 +20,12 @@ jobs:
           IMAGE_TAG: 'v0.0'
           DOCKERFILE_PATH: '.github/docker/Dockerfile'
           BUILD_CONTEXT: './'
+      - name: Build and Publish Docker image in GPR
+        uses: saubermacherag/gpr-docker-publish@master
+        with:
+          USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          PASSWORD: ${{ secrets.DOCKERHUB_PAT }}
+          IMAGE_TAG: 'v0.0'
+          DOCKERFILE_PATH: '.github/docker/Dockerfile'
+          BUILD_CONTEXT: './'
+          DOCKERHUB_REPOSITORY: 'pinkrobin/docker-ansible-alpine'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Created by .ignore support plugin (hsz.mobi)
+.idea

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ jobs:
         DOCKERFILE_PATH: 'argo/gpu.Dockerfile'
         BUILD_CONTEXT: 'argo/'
 
+    #To access another docker registry like dockerhub you'll have to add `DOCKERHUB_UERNAME` and `DOCKERHUB_PAT` in github secrets.
+    - name: Build and Publish Docker image to Dockerhub instead of GPR
+      uses: saubermacherag/gpr-docker-publish@master
+      with:
+        USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        PASSWORD: ${{ secrets.DOCKERHUB_PAT }}
+        IMAGE_TAG: 'v0.0'
+        DOCKERFILE_PATH: '.github/docker/Dockerfile'
+        BUILD_CONTEXT: './'
+        DOCKERHUB_REPOSITORY: 'pinkrobin/gpr-docker-publish-example'
+
     # This second step is illustrative and shows how to reference the 
     # output variables.  This is completely optional.
     - name: Show outputs of pervious step

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ jobs:
 
 1. `cache`: if value is `true`, attempts to use the last pushed image as a cache.  Default value is `false`.
 2. `IMAGE_TAG`: if value is set, use provided value.  Default value is the first 12 characters of the GitHub SHA that triggered the action.
+3. `DOCKERHUB_REPOSITORY`: if value is set, you don't need to set `IMAGE_NAME`. It will push the image to the given dockerhub repository instead of using GPR.
+Why? Because Github Actions don't support downloading images without authentication at the moment. See: https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/m-p/32782
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Where:
 - `Image_Name` is provided by the user as an input.
 - `IMAGE_TAG` is either the first 12 characters of the GitHub commit SHA or the value of INPUT_IMAGE_TAG env variable
 
+Additionally it will use Git Tags pointing to the HEAD commit to create docker tags accordingly. 
+E.g. Git Tag v1.1 will result in an additional docker tag v1.1.
+
 ## Usage
 
 
@@ -52,6 +55,7 @@ jobs:
         USERNAME: ${{ secrets.DOCKER_USERNAME }}
         PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         IMAGE_NAME: 'test-docker-action'
+        IMAGE_TAG: 'v0.0'
         DOCKERFILE_PATH: 'argo/gpu.Dockerfile'
         BUILD_CONTEXT: 'argo/'
 
@@ -68,8 +72,8 @@ jobs:
 
 ### Mandatory Inputs
 
-1. `USERNAME` the login username, most likely your github handle.  This username must have write access to the repo where the action is called.
-2. `PASSWORD` Your GitHub password that has write access to the repo where this action is called.
+1. `USERNAME` the login username, most likely your github handle.  This username must have write access to the repo where the action is called. `x-access-token` should suffice.
+2. `PASSWORD` Your GitHub password that has write access to the repo where this action is called. `${{ secrets.GITHUB_TOKEN }}` should suffice.
 3. `IMAGE_NAME` is the name of the image you would like to push  
 4. `DOCKERFILE_PATH`: The full path (including the filename) relative to the root of the repository that contains the Dockerfile that specifies your build.
 5. `BUILD_CONTEXT`: The directory for the build context.  See these [docs](https://docs.docker.com/engine/reference/commandline/build/) for more information on the definition of build context.

--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,9 @@ inputs:
   image_tag:
     description: Optional input to set a tag name instead of a hash.
     required: false
+  dockerhub_repository:
+    description: Optional input to push image to dockerhub repository instead of GPR.
+    required: false
 outputs:
   IMAGE_SHA_NAME:
     description: name of the Docker Image including the tag

--- a/action.yaml
+++ b/action.yaml
@@ -10,19 +10,22 @@ inputs:
     require: true
   image_name:
     description: name of the image.  Example - myContainer
-    require: true
+    required: true
   build_context:
     description: the path in your repo that will serve as the build context
-    require: true
+    required: true
     default: './'
   dockerfile_path:
     description: the full path (including the filename) to the dockerfile that you want to build
-    require: true
+    required: true
     default: ./Dockerfile
   cache:
     description: attempt to use last image as the cache
-    require: false
+    required: false
     default: false
+  image_tag:
+    description: Optional input to set a tag name instead of a hash.
+    required: false
 outputs:
   IMAGE_SHA_NAME:
     description: name of the Docker Image including the tag


### PR DESCRIPTION
I added the functionality to implicitly use Git Tags as additional Docker Tags. Means: If you commit a new Git Tag, an appropriate additional Docker Tag with the same name is going to be created as well.
I fixed a few typos and introduced a Github Workflow to get this action tested.

I already did an integration test by using this functionality here:
https://github.com/saubermacherag/docker-ansible-alpine

The big advantage I see is that you can comfortably draft a realease on Github which implicitly creates a GIT tag which will also become the docker tag.

I would be very greatful if you accept this request :-D
And furthermore if you're pull request to the original repository gets accepted.